### PR TITLE
Fix capacity check in Slab constructor and grow, and use of entries.capacity() instead of entries.len().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl<T, I: Into<usize> + From<usize>> Slab<T, I> {
 
     #[inline]
     pub fn remaining(&self) -> usize {
-        self.entries.capacity() - self.len
+        self.entries.len() - self.len
     }
 
     #[inline]
@@ -312,7 +312,7 @@ impl<T, I: Into<usize> + From<usize>> Slab<T, I> {
 
         let idx = idx - self.offset;
 
-        if idx >= self.entries.capacity() {
+        if idx >= self.entries.len() {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ impl<T, I: Into<usize> + From<usize>> Slab<T, I> {
     }
 
     pub fn new_starting_at(offset: I, capacity: usize) -> Slab<T, I> {
-        assert!(capacity <= usize::MAX, "capacity too large");
+        let offset = offset.into();
+        assert!(capacity < usize::MAX - offset, "capacity too large");
         let entries = (1..capacity + 1)
             .map(Slot::Empty)
             .collect::<Vec<_>>();
@@ -63,11 +64,10 @@ impl<T, I: Into<usize> + From<usize>> Slab<T, I> {
             entries: entries,
             next: 0,
             len: 0,
-            offset: offset.into(),
+            offset: offset,
             _marker: PhantomData,
         }
     }
-
     #[inline]
     pub fn count(&self) -> usize {
         self.len
@@ -283,6 +283,7 @@ impl<T, I: Into<usize> + From<usize>> Slab<T, I> {
     /// Grow the slab, by adding `entries_num`
     pub fn grow(&mut self, entries_num: usize) {
         let prev_len = self.entries.len();
+        assert!(entries_num < usize::MAX - self.offset - prev_len, "capacity too large");
         let prev_len_next = prev_len + 1;
         self.entries.extend((prev_len_next..(prev_len_next + entries_num)).map(|n| Slot::Empty(n)));
         debug_assert_eq!(self.entries.len(), prev_len + entries_num);
@@ -732,6 +733,28 @@ mod tests {
     fn test_accessing_out_of_bounds() {
         let slab = Slab::<usize, usize>::new(16);
         slab[0];
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_capacity_too_large1() {
+        use std::usize;
+        Slab::<usize, usize>::new(usize::MAX);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_capacity_too_large2() {
+        use std::usize;
+        Slab::<usize, usize>::new_starting_at(usize::MAX - 100, 100);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_capacity_too_large_in_grow() {
+        use std::usize;
+        let mut slab = Slab::<usize, usize>::new(100);
+        slab.grow(usize::MAX - 100);
     }
 
     #[test]


### PR DESCRIPTION
This pull request fixes two minor issues, first one is:

    Fix capacity check in Slab::new_starting_at and add one in Slab::grow.
    
    Check for potential integer overflows resulting from the index
    calculations. We need to ensure that adding offset and using
    past-the-end index for next will not cause overflow. In other words,
    assert that:
      capacity + offset + 1 <= usize::MAX
    which can be safely done as:
      capacity < usize::MAX - offset
    Similar check is required in Slab::grow.

second one is:

    Replace uses of entries.capacity() with entries.len().
    
    Avoid relaying on the assumption that entries.capacity() is equal to
    entries.len(). It is not necessarily true, especially after using grow.