### PR TITLE
LIFO reuse of slots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ impl<'a, T, I: From<usize> + Into<usize>> Entry<'a, T, I> {
 
     /// Remove and return the value stored in the entry
     pub fn remove(self) -> T {
-        let next = self.slab.next;
+        let next = mem::replace(&mut self.slab.next, self.idx);
 
         if let Some(v) = self.slab.replace(self.idx, Slot::Empty(next)) {
             self.slab.len -= 1;
@@ -833,5 +833,19 @@ mod tests {
 
         let vals: Vec<u32> = slab.iter().map(|r| *r).collect();
         assert_eq!(vals, vec![]);
+    }
+
+    #[test]
+    fn test_lifo() {
+        let mut slab = Slab::<u32, usize>::with_capacity(4);
+        let idx0 = slab.insert(0).unwrap();
+        let idx1 = slab.insert(0).unwrap();
+        let idx2 = slab.insert(0).unwrap();
+        slab.remove(idx2).unwrap();
+        slab.remove(idx0).unwrap();
+        slab.remove(idx1).unwrap();
+        assert_eq!(slab.insert(1).unwrap(), idx1);
+        assert_eq!(slab.insert(1).unwrap(), idx0);
+        assert_eq!(slab.insert(1).unwrap(), idx2);
     }
 }


### PR DESCRIPTION
I can't prove it but with LIFO reuse there's a higher chance that the used slots will be closer together in memory.

Scenario 1, uniformly lived slots:
LIFO will keep working set (slots will be together) at the beginning of the vector.
FIFO will move the working set (slots will be together) along the vector.

Scenario 2, random lived slots:
LIFO will keep working set at the beginning of the vector (in some cases).
FIFO will spread the working set along the vector.