### PR TITLE
Rewrite slab making it more idiomatic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 rust:
   - nightly
   - stable
-  - 1.3.0
+  - 1.6.0
 
 script:
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,13 @@
 [package]
 
 name = "slab"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
-description = "Simple slab allocator"
-documentation = "https://docs.rs/slab/0.3.0/slab/"
+description = "Pre-allocated storage for a uniform data type"
+documentation = "https://docs.rs/slab"
 homepage = "https://github.com/carllerche/slab"
 repository = "https://github.com/carllerche/slab"
 readme = "README.md"
 keywords = ["slab", "allocator"]
-categories = ["memory-management"]
-exclude = [
-    ".gitignore",
-    ".travis.yml",
-    "test/**/*",
-]
+categories = ["memory-management", "data-structures"]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2017 Carl Lerche
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
-Slab Allocator for Rust
+# Slab
 
-Preallocate memory for values of a given type.
+Pre-allocated storage for a uniform data type.
+
+[![Crates.io](https://img.shields.io/crates/v/slab.svg?maxAge=2592000)](https://crates.io/crates/slab)
+[![Build Status](https://travis-ci.org/carllerche/slab.svg?branch=master)](https://travis-ci.org/carllerche/slab)
+
+[Documentation](https://docs.rs/slab)
+
+## Usage
+
+To use `slab`, first add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+slab = "0.4"
+```
+
+Next, add this to your crate:
+
+```rust
+extern crate slab;
+
+use slab::Slab;
+
+let mut slab = Slab::new();
+
+let hello = slab.insert("hello");
+let world = slab.insert("world");
+
+assert_eq!(slab[hello], "hello");
+assert_eq!(slab[world], "world");
+
+slab[world] = "earth";
+assert_eq!(slab[world], "earth");
+```
+
+See [documentation](https://docs.rs/slab) for more details.
+
+# License
+
+`slab` is primarily distributed under the terms of both the MIT license and the
+Apache License (Version 2.0), with portions covered by various BSD-like
+licenses.
+
+See LICENSE-APACHE, and LICENSE-MIT for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,11 +661,11 @@ impl<T> Slab<T> {
     /// This method operates in place and preserves the order of the retained
     /// elements.
     pub fn retain<F>(&mut self, mut f: F)
-        where F: FnMut(&T) -> bool
+        where F: FnMut(&mut T) -> bool
     {
         for i in 0..self.entries.len() {
             let keep = match self.entries[i] {
-                Entry::Occupied(ref v) => f(v),
+                Entry::Occupied(ref mut v) => f(v),
                 _ => true,
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,6 +812,24 @@ impl<'a, T> VacantEntry<'a, T> {
     ///
     /// To get the key associated with the value, use `key` prior to calling
     /// `insert`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slab::*;
+    /// let mut slab = Slab::new();
+    ///
+    /// let hello = {
+    ///     let entry = slab.vacant_entry();
+    ///     let key = entry.key();
+    ///
+    ///     entry.insert((key, "hello"));
+    ///     key
+    /// };
+    ///
+    /// assert_eq!(hello, slab[hello].0);
+    /// assert_eq!("hello", slab[hello].1);
+    /// ```
     pub fn insert(self, val: T) -> &'a mut T {
         self.slab.insert_at(self.key, val);
 
@@ -824,6 +842,24 @@ impl<'a, T> VacantEntry<'a, T> {
     /// Return the key associated with this entry.
     ///
     /// A value stored in this entry will be associated with this key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slab::*;
+    /// let mut slab = Slab::new();
+    ///
+    /// let hello = {
+    ///     let entry = slab.vacant_entry();
+    ///     let key = entry.key();
+    ///
+    ///     entry.insert((key, "hello"));
+    ///     key
+    /// };
+    ///
+    /// assert_eq!(hello, slab[hello].0);
+    /// assert_eq!("hello", slab[hello].1);
+    /// ```
     pub fn key(&self) -> usize {
         self.key
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! It is important to note that keys may be reused. In other words, once a
 //! value associated with a given key is removed from a slab, that key may be
-//! returned from future calls to `store`.
+//! returned from future calls to `insert`.
 //!
 //! # Examples
 //!
@@ -22,8 +22,8 @@
 //! # use slab::*;
 //! let mut slab = Slab::new();
 //!
-//! let hello = slab.store("hello");
-//! let world = slab.store("world");
+//! let hello = slab.insert("hello");
+//! let world = slab.insert("world");
 //!
 //! assert_eq!(slab[hello], "hello");
 //! assert_eq!(slab[world], "world");
@@ -33,7 +33,7 @@
 //! ```
 //!
 //! Sometimes it is useful to be able to associate the key with the value being
-//! stored in the slab. This can be done with the `slot` API as such:
+//! inserted in the slab. This can be done with the `slot` API as such:
 //!
 //! ```
 //! # use slab::*;
@@ -43,7 +43,7 @@
 //!     let slot = slab.slot();
 //!     let key = slot.key();
 //!
-//!     slot.store((key, "hello"));
+//!     slot.insert((key, "hello"));
 //!     key
 //! };
 //!
@@ -53,7 +53,7 @@
 //!
 //! It is generally a good idea to specify the desired capacity of a slab at
 //! creation time. Note that `Slab` will grow the internal capacity when
-//! attempting to store a new value once the existing capacity has been reached.
+//! attempting to insert a new value once the existing capacity has been reached.
 //! To avoid this, add a check.
 //!
 //! ```
@@ -66,23 +66,24 @@
 //!     panic!("slab full");
 //! }
 //!
-//! slab.store("the slab is not at capacity yet");
+//! slab.insert("the slab is not at capacity yet");
 //! ```
 //!
 //! # Capacity and reallocation
 //!
 //! The capacity of a slab is the amount of space allocated for any future
-//! values that will be stored in the slab. This is not to be confused with the
-//! *length* of the slab, which specifies the number of actual values currently
-//! being stored. If a slab's length is equal to its capacity, the next value
-//! stored into the slab will require growing the slab by reallocating.
+//! values that will be inserted in the slab. This is not to be confused with
+//! the *length* of the slab, which specifies the number of actual values
+//! currently being inserted. If a slab's length is equal to its capacity, the
+//! next value inserted into the slab will require growing the slab by
+//! reallocating.
 //!
 //! For example, a slab with capacity 10 and length 0 would be an empty slab
 //! with space for 10 more stored values. Storing 10 or fewer elements into the
 //! slab will not change its capacity or cause reallocation to occur. However,
-//! if the slab length is increased to 11 (due to another `store`), it will have
-//! to reallocate, which can be slow. For this reason, it is recommended to use
-//! [`Slab::with_capacity`] whenever possible to specify how many values the
+//! if the slab length is increased to 11 (due to another `insert`), it will
+//! have to reallocate, which can be slow. For this reason, it is recommended to
+//! use [`Slab::with_capacity`] whenever possible to specify how many values the
 //! slab is expected to store.
 //!
 //! # Implementation
@@ -139,7 +140,7 @@ pub struct Slab<T> {
 ///     let slot = slab.slot();
 ///     let key = slot.key();
 ///
-///     slot.store((key, "hello"));
+///     slot.insert((key, "hello"));
 ///     key
 /// };
 ///
@@ -176,7 +177,7 @@ impl<T> Slab<T> {
     /// Construct a new, empty `Slab`.
     ///
     /// The function does not allocate and the returned slab will have no
-    /// capacity until `store` is called or capacity is explicitly reserved.
+    /// capacity until `insert` is called or capacity is explicitly reserved.
     ///
     /// # Examples
     ///
@@ -209,11 +210,11 @@ impl<T> Slab<T> {
     ///
     /// // These are all done without reallocating...
     /// for i in 0..10 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// // ...but this may make the slab reallocate
-    /// slab.store(11);
+    /// slab.insert(11);
     /// ```
     pub fn with_capacity(capacity: usize) -> Slab<T> {
         Slab {
@@ -258,7 +259,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// slab.store("hello");
+    /// slab.insert("hello");
     /// slab.reserve(10);
     /// assert!(slab.capacity() >= 11);
     /// ```
@@ -294,7 +295,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// slab.store("hello");
+    /// slab.insert("hello");
     /// slab.reserve_exact(10);
     /// assert!(slab.capacity() >= 11);
     /// ```
@@ -322,7 +323,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::with_capacity(10);
     ///
     /// for i in 0..3 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// assert_eq!(slab.capacity(), 10);
@@ -338,7 +339,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::with_capacity(10);
     ///
     /// for i in 0..3 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// slab.remove(0);
@@ -361,7 +362,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::new();
     ///
     /// for i in 0..3 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// slab.clear();
@@ -382,7 +383,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::new();
     ///
     /// for i in 0..3 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// assert_eq!(3, slab.len());
@@ -400,7 +401,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::new();
     /// assert!(slab.is_empty());
     ///
-    /// slab.store(1);
+    /// slab.insert(1);
     /// assert!(!slab.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -421,7 +422,7 @@ impl<T> Slab<T> {
     /// let mut slab = Slab::new();
     ///
     /// for i in 0..3 {
-    ///     slab.store(i);
+    ///     slab.insert(i);
     /// }
     ///
     /// let mut iterator = slab.iter();
@@ -451,8 +452,8 @@ impl<T> Slab<T> {
     /// # use slab::*;
     /// let mut slab = Slab::new();
     ///
-    /// let key1 = slab.store(0);
-    /// let key2 = slab.store(1);
+    /// let key1 = slab.insert(0);
+    /// let key2 = slab.insert(1);
     ///
     /// for (key, val) in slab.iter_mut() {
     ///     if key == key1 {
@@ -481,7 +482,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// let key = slab.store("hello");
+    /// let key = slab.insert("hello");
     ///
     /// assert_eq!(slab.get(key), Some(&"hello"));
     /// assert_eq!(slab.get(123), None);
@@ -503,7 +504,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// let key = slab.store("hello");
+    /// let key = slab.insert("hello");
     ///
     /// *slab.get_mut(key).unwrap() = "world";
     ///
@@ -527,7 +528,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// let key = slab.store(2);
+    /// let key = slab.insert(2);
     ///
     /// unsafe {
     ///     assert_eq!(slab.get_unchecked(key), &2);
@@ -550,7 +551,7 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// let key = slab.store(2);
+    /// let key = slab.insert(2);
     ///
     /// unsafe {
     ///     let val = slab.get_unchecked_mut(key);
@@ -566,7 +567,7 @@ impl<T> Slab<T> {
         }
     }
 
-    /// Store a value in the slab, returning key assigned to the value
+    /// Insert a value in the slab, returning key assigned to the value
     ///
     /// The returned key can later be used to retrieve or remove the value using indexed
     /// lookup and `remove`. Additional capacity is allocated if needed. See
@@ -581,13 +582,13 @@ impl<T> Slab<T> {
     /// ```
     /// # use slab::*;
     /// let mut slab = Slab::new();
-    /// let key = slab.store("hello");
+    /// let key = slab.insert("hello");
     /// assert_eq!(slab[key], "hello");
     /// ```
-    pub fn store(&mut self, val: T) -> usize {
+    pub fn insert(&mut self, val: T) -> usize {
         let key = self.next;
 
-        self.store_at(key, val);
+        self.insert_at(key, val);
 
         key
     }
@@ -600,8 +601,7 @@ impl<T> Slab<T> {
         }
     }
 
-    /// Store the value at the given key
-    fn store_at(&mut self, key: usize, val: T) {
+    fn insert_at(&mut self, key: usize, val: T) {
         self.len += 1;
 
         if key == self.entries.len() {
@@ -737,12 +737,12 @@ impl<'a, T: 'a> fmt::Debug for IterMut<'a, T> where T: fmt::Debug {
 // ===== Slot =====
 
 impl<'a, T> Slot<'a, T> {
-    /// Store a value in the slot, returning a mutable reference to the value.
+    /// Insert a value in the slot, returning a mutable reference to the value.
     ///
     /// To get the key associated with the value, use `key` prior to calling
-    /// `store`.
-    pub fn store(self, val: T) -> &'a mut T {
-        self.slab.store_at(self.key, val);
+    /// `insert`.
+    pub fn insert(self, val: T) -> &'a mut T {
+        self.slab.insert_at(self.key, val);
 
         match self.slab.entries[self.key] {
             Entry::Occupied(ref mut v) => v,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 #![doc(html_root_url = "https://docs.rs/slab/0.4")]
 #![crate_name = "slab"]
 
-use std::{fmt, mem, usize};
+use std::{fmt, mem};
 use std::iter::IntoIterator;
 use std::ops;
 use std::marker::PhantomData;
@@ -160,7 +160,6 @@ pub struct Iter<'a, T: 'a> {
 }
 
 /// A mutable iterator over the values stored in the `Slab`
-#[derive(Debug)]
 pub struct IterMut<'a, T: 'a> {
     slab: *mut Slab<T>,
     curr: usize,
@@ -721,6 +720,15 @@ impl<T> fmt::Debug for Slab<T> where T: fmt::Debug {
                "Slab {{ len: {}, cap: {} }}",
                self.len,
                self.capacity())
+    }
+}
+
+impl<'a, T: 'a> fmt::Debug for IterMut<'a, T> where T: fmt::Debug {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("IterMut")
+            .field("slab", unsafe { &*self.slab })
+            .field("curr", &self.curr)
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,17 @@
 //! ```
 //!
 //! Sometimes it is useful to be able to associate the key with the value being
-//! inserted in the slab. This can be done with the `slot` API as such:
+//! inserted in the slab. This can be done with the `vacant_entry` API as such:
 //!
 //! ```
 //! # use slab::*;
 //! let mut slab = Slab::new();
 //!
 //! let hello = {
-//!     let slot = slab.slot();
-//!     let key = slot.key();
+//!     let entry = slab.vacant_entry();
+//!     let key = entry.key();
 //!
-//!     slot.insert((key, "hello"));
+//!     entry.insert((key, "hello"));
 //!     key
 //! };
 //!
@@ -125,10 +125,10 @@ pub struct Slab<T> {
     next: usize,
 }
 
-/// A handle to an empty slot in a `Slab`.
+/// A handle to an vacant entry in a `Slab`.
 ///
-/// `Slot` allows constructing values with the key that they will be assigned
-/// to.
+/// `VacantEntry` allows constructing values with the key that they will be
+/// assigned to.
 ///
 /// # Examples
 ///
@@ -137,10 +137,10 @@ pub struct Slab<T> {
 /// let mut slab = Slab::new();
 ///
 /// let hello = {
-///     let slot = slab.slot();
-///     let key = slot.key();
+///     let entry = slab.vacant_entry();
+///     let key = entry.key();
 ///
-///     slot.insert((key, "hello"));
+///     entry.insert((key, "hello"));
 ///     key
 /// };
 ///
@@ -148,7 +148,7 @@ pub struct Slab<T> {
 /// assert_eq!("hello", slab[hello].1);
 /// ```
 #[derive(Debug)]
-pub struct Slot<'a, T: 'a> {
+pub struct VacantEntry<'a, T: 'a> {
     slab: &'a mut Slab<T>,
     key: usize,
 }
@@ -593,9 +593,9 @@ impl<T> Slab<T> {
         key
     }
 
-    /// Returns a handle to a vaccant slot allowing for further manipulation.
-    pub fn slot(&mut self) -> Slot<T> {
-        Slot {
+    /// Returns a handle to a vacant entry allowing for further manipulation.
+    pub fn vacant_entry(&mut self) -> VacantEntry<T> {
+        VacantEntry {
             key: self.next,
             slab: self,
         }
@@ -734,10 +734,10 @@ impl<'a, T: 'a> fmt::Debug for IterMut<'a, T> where T: fmt::Debug {
     }
 }
 
-// ===== Slot =====
+// ===== VacantEntry =====
 
-impl<'a, T> Slot<'a, T> {
-    /// Insert a value in the slot, returning a mutable reference to the value.
+impl<'a, T> VacantEntry<'a, T> {
+    /// Insert a value in the entry, returning a mutable reference to the value.
     ///
     /// To get the key associated with the value, use `key` prior to calling
     /// `insert`.
@@ -750,9 +750,9 @@ impl<'a, T> Slot<'a, T> {
         }
     }
 
-    /// Return the key associated with this slot.
+    /// Return the key associated with this entry.
     ///
-    /// A value stored in this slot will be associated with this key.
+    /// A value stored in this entry will be associated with this key.
     pub fn key(&self) -> usize {
         self.key
     }

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -185,12 +185,15 @@ fn iter() {
         slab.store(i);
     }
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().enumerate().map(|(i, (key, val))| {
+        assert_eq!(i, key);
+        *val
+    }).collect();
     assert_eq!(vals, vec![0, 1, 2, 3]);
 
     slab.remove(1);
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![0, 2, 3]);
 }
 
@@ -202,20 +205,21 @@ fn iter_mut() {
         slab.store(i);
     }
 
-    for e in slab.iter_mut() {
+    for (i, (key, e)) in slab.iter_mut().enumerate() {
+        assert_eq!(i, key);
         *e = *e + 1;
     }
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![1, 2, 3, 4]);
 
     slab.remove(2);
 
-    for e in slab.iter_mut() {
+    for (_, e) in slab.iter_mut() {
         *e = *e + 1;
     }
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![2, 3, 5]);
 }
 
@@ -230,7 +234,7 @@ fn clear() {
     // clear full
     slab.clear();
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert!(vals.is_empty());
 
     assert_eq!(0, slab.len());
@@ -240,12 +244,12 @@ fn clear() {
         slab.store(i);
     }
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![0, 1]);
 
     // clear half-filled
     slab.clear();
 
-    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert!(vals.is_empty());
 }

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -151,27 +151,6 @@ fn reserve_exact_does_not_allocate_if_available() {
 }
 
 #[test]
-fn test_key_trait() {
-    #[derive(Debug, Eq, PartialEq)]
-    struct MyKey(usize);
-
-    impl From<usize> for MyKey {
-        fn from(i: usize) -> MyKey { MyKey(i) }
-    }
-
-    impl Into<usize> for MyKey {
-        fn into(self) -> usize { self.0 }
-    }
-
-    let mut slab = Slab::with_capacity_and_key_type(1);
-    let key: MyKey = slab.store(10);
-
-    assert_eq!(key, MyKey(0));
-    assert_eq!(slab[key], 10);
-}
-
-
-#[test]
 fn retain() {
     let mut slab = Slab::with_capacity(2);
 

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -153,7 +153,7 @@ fn reserve_exact_does_not_allocate_if_available() {
 #[test]
 fn test_key_trait() {
     #[derive(Debug, Eq, PartialEq)]
-    pub struct MyKey(usize);
+    struct MyKey(usize);
 
     impl From<usize> for MyKey {
         fn from(i: usize) -> MyKey { MyKey(i) }

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -157,7 +157,7 @@ fn retain() {
     let key1 = slab.store(0);
     let key2 = slab.store(1);
 
-    slab.retain(|x| x % 2 == 0);
+    slab.retain(|x| *x % 2 == 0);
 
     assert_eq!(slab.len(), 1);
     assert_eq!(slab[key1], 0);

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -3,11 +3,11 @@ extern crate slab;
 use slab::*;
 
 #[test]
-fn store_get_remove_one() {
+fn insert_get_remove_one() {
     let mut slab = Slab::new();
     assert!(slab.is_empty());
 
-    let key = slab.store(10);
+    let key = slab.insert(10);
 
     assert_eq!(slab[key], 10);
     assert_eq!(slab.get(key), Some(&10));
@@ -20,18 +20,18 @@ fn store_get_remove_one() {
 }
 
 #[test]
-fn store_get_many() {
+fn insert_get_many() {
     let mut slab = Slab::with_capacity(10);
 
     for i in 0..10 {
-        let key = slab.store(i + 10);
+        let key = slab.insert(i + 10);
         assert_eq!(slab[key], i + 10);
     }
 
     assert_eq!(slab.capacity(), 10);
 
     // Storing another one grows the slab
-    let key = slab.store(20);
+    let key = slab.insert(20);
     assert_eq!(slab[key], 20);
 
     // Capacity grows by 2x
@@ -39,7 +39,7 @@ fn store_get_many() {
 }
 
 #[test]
-fn store_get_remove_many() {
+fn insert_get_remove_many() {
     let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
@@ -47,7 +47,7 @@ fn store_get_remove_many() {
         for j in 0..10 {
             let val = (i * 10) + j;
 
-            let key = slab.store(val);
+            let key = slab.insert(val);
             keys.push((key, val));
             assert_eq!(slab[key], val);
         }
@@ -61,14 +61,14 @@ fn store_get_remove_many() {
 }
 
 #[test]
-fn store_with_slot() {
+fn insert_with_slot() {
     let mut slab = Slab::with_capacity(1);
     let key;
 
     {
         let slot = slab.slot();
         key = slot.key();
-        slot.store(123);
+        slot.insert(123);
     }
 
     assert_eq!(123, slab[key]);
@@ -92,7 +92,7 @@ fn invalid_get_panics() {
 #[should_panic]
 fn double_remove_panics() {
     let mut slab = Slab::<usize>::with_capacity(1);
-    let key = slab.store(123);
+    let key = slab.insert(123);
     slab.remove(key);
     slab.remove(key);
 }
@@ -107,7 +107,7 @@ fn invalid_remove_panics() {
 #[test]
 fn slab_get_mut() {
     let mut slab = Slab::new();
-    let key = slab.store(1);
+    let key = slab.insert(1);
 
     slab[key] = 2;
     assert_eq!(slab[key], 2);
@@ -122,7 +122,7 @@ fn reserve_does_not_allocate_if_available() {
     let mut keys = vec![];
 
     for i in 0..10 {
-        keys.push(slab.store(i));
+        keys.push(slab.insert(i));
     }
 
     for key in keys {
@@ -139,7 +139,7 @@ fn reserve_exact_does_not_allocate_if_available() {
     let mut keys = vec![];
 
     for i in 0..10 {
-        keys.push(slab.store(i));
+        keys.push(slab.insert(i));
     }
 
     for key in keys {
@@ -154,8 +154,8 @@ fn reserve_exact_does_not_allocate_if_available() {
 fn retain() {
     let mut slab = Slab::with_capacity(2);
 
-    let key1 = slab.store(0);
-    let key2 = slab.store(1);
+    let key1 = slab.insert(0);
+    let key2 = slab.insert(1);
 
     slab.retain(|x| *x % 2 == 0);
 
@@ -164,14 +164,14 @@ fn retain() {
     assert!(!slab.contains(key2));
 
     // Ensure consistency is retained
-    let key = slab.store(123);
+    let key = slab.insert(123);
     assert_eq!(key, key2);
 
     assert_eq!(2, slab.len());
     assert_eq!(2, slab.capacity());
 
     // Inserting another element grows
-    let key = slab.store(345);
+    let key = slab.insert(345);
     assert_eq!(key, 2);
 
     assert_eq!(4, slab.capacity());
@@ -182,7 +182,7 @@ fn iter() {
     let mut slab = Slab::new();
 
     for i in 0..4 {
-        slab.store(i);
+        slab.insert(i);
     }
 
     let vals: Vec<_> = slab.iter().enumerate().map(|(i, (key, val))| {
@@ -202,7 +202,7 @@ fn iter_mut() {
     let mut slab = Slab::new();
 
     for i in 0..4 {
-        slab.store(i);
+        slab.insert(i);
     }
 
     for (i, (key, e)) in slab.iter_mut().enumerate() {
@@ -228,7 +228,7 @@ fn clear() {
     let mut slab = Slab::new();
 
     for i in 0..4 {
-        slab.store(i);
+        slab.insert(i);
     }
 
     // clear full
@@ -241,7 +241,7 @@ fn clear() {
     assert_eq!(4, slab.capacity());
 
     for i in 0..2 {
-        slab.store(i);
+        slab.insert(i);
     }
 
     let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -4,7 +4,7 @@ use slab::*;
 
 #[test]
 fn store_get_remove_one() {
-    let mut slab = Slab::<_, usize>::new();
+    let mut slab = Slab::new();
     assert!(slab.is_empty());
 
     let key = slab.store(10);
@@ -21,7 +21,7 @@ fn store_get_remove_one() {
 
 #[test]
 fn store_get_many() {
-    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut slab = Slab::with_capacity(10);
 
     for i in 0..10 {
         let key = slab.store(i + 10);
@@ -40,7 +40,7 @@ fn store_get_many() {
 
 #[test]
 fn store_get_remove_many() {
-    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
     for i in 0..10 {
@@ -62,7 +62,7 @@ fn store_get_remove_many() {
 
 #[test]
 fn store_with_slot() {
-    let mut slab = Slab::<_, usize>::with_capacity(1);
+    let mut slab = Slab::with_capacity(1);
     let key;
 
     {
@@ -76,7 +76,7 @@ fn store_with_slot() {
 
 #[test]
 fn get_slot_without_using() {
-    let mut slab = Slab::<usize, usize>::with_capacity(1);
+    let mut slab = Slab::<usize>::with_capacity(1);
     let key = slab.slot().key();
     assert_eq!(key, slab.slot().key());
 }
@@ -84,14 +84,14 @@ fn get_slot_without_using() {
 #[test]
 #[should_panic]
 fn invalid_get_panics() {
-    let slab = Slab::<usize, usize>::with_capacity(1);
+    let slab = Slab::<usize>::with_capacity(1);
     slab[0];
 }
 
 #[test]
 #[should_panic]
 fn double_remove_panics() {
-    let mut slab = Slab::<_, usize>::with_capacity(1);
+    let mut slab = Slab::<usize>::with_capacity(1);
     let key = slab.store(123);
     slab.remove(key);
     slab.remove(key);
@@ -100,13 +100,13 @@ fn double_remove_panics() {
 #[test]
 #[should_panic]
 fn invalid_remove_panics() {
-    let mut slab = Slab::<usize, usize>::with_capacity(1);
+    let mut slab = Slab::<usize>::with_capacity(1);
     slab.remove(0);
 }
 
 #[test]
 fn slab_get_mut() {
-    let mut slab = Slab::<_, usize>::new();
+    let mut slab = Slab::new();
     let key = slab.store(1);
 
     slab[key] = 2;
@@ -118,7 +118,7 @@ fn slab_get_mut() {
 
 #[test]
 fn reserve_does_not_allocate_if_available() {
-    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
     for i in 0..10 {
@@ -135,7 +135,7 @@ fn reserve_does_not_allocate_if_available() {
 
 #[test]
 fn reserve_exact_does_not_allocate_if_available() {
-    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
     for i in 0..10 {
@@ -163,7 +163,7 @@ fn test_key_trait() {
         fn into(self) -> usize { self.0 }
     }
 
-    let mut slab = Slab::<_, MyKey>::with_capacity(1);
+    let mut slab = Slab::with_capacity_and_key_type(1);
     let key: MyKey = slab.store(10);
 
     assert_eq!(key, MyKey(0));
@@ -173,7 +173,7 @@ fn test_key_trait() {
 
 #[test]
 fn retain() {
-    let mut slab = Slab::<_, usize>::with_capacity(2);
+    let mut slab = Slab::with_capacity(2);
 
     let key1 = slab.store(0);
     let key2 = slab.store(1);
@@ -200,7 +200,7 @@ fn retain() {
 
 #[test]
 fn iter() {
-    let mut slab = Slab::<_, usize>::new();
+    let mut slab = Slab::new();
 
     for i in 0..4 {
         slab.store(i);
@@ -217,7 +217,7 @@ fn iter() {
 
 #[test]
 fn iter_mut() {
-    let mut slab = Slab::<_, usize>::new();
+    let mut slab = Slab::new();
 
     for i in 0..4 {
         slab.store(i);
@@ -242,7 +242,7 @@ fn iter_mut() {
 
 #[test]
 fn clear() {
-    let mut slab = Slab::<_, usize>::new();
+    let mut slab = Slab::new();
 
     for i in 0..4 {
         slab.store(i);

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -1,0 +1,272 @@
+extern crate slab;
+
+use slab::*;
+
+#[test]
+fn store_get_remove_one() {
+    let mut slab = Slab::<_, usize>::new();
+    assert!(slab.is_empty());
+
+    let key = slab.store(10);
+
+    assert_eq!(slab[key], 10);
+    assert_eq!(slab.get(key), Some(&10));
+    assert!(!slab.is_empty());
+    assert!(slab.contains(key));
+
+    assert_eq!(slab.remove(key), 10);
+    assert!(!slab.contains(key));
+    assert!(slab.get(key).is_none());
+}
+
+#[test]
+fn store_get_many() {
+    let mut slab = Slab::<_, usize>::with_capacity(10);
+
+    for i in 0..10 {
+        let key = slab.store(i + 10);
+        assert_eq!(slab[key], i + 10);
+    }
+
+    assert_eq!(slab.capacity(), 10);
+
+    // Storing another one grows the slab
+    let key = slab.store(20);
+    assert_eq!(slab[key], 20);
+
+    // Capacity grows by 2x
+    assert_eq!(slab.capacity(), 20);
+}
+
+#[test]
+fn store_get_remove_many() {
+    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut keys = vec![];
+
+    for i in 0..10 {
+        for j in 0..10 {
+            let val = (i * 10) + j;
+
+            let key = slab.store(val);
+            keys.push((key, val));
+            assert_eq!(slab[key], val);
+        }
+
+        for (key, val) in keys.drain(..) {
+            assert_eq!(val, slab.remove(key));
+        }
+    }
+
+    assert_eq!(10, slab.capacity());
+}
+
+#[test]
+fn store_with_slot() {
+    let mut slab = Slab::<_, usize>::with_capacity(1);
+    let key;
+
+    {
+        let slot = slab.slot();
+        key = slot.key();
+        slot.store(123);
+    }
+
+    assert_eq!(123, slab[key]);
+}
+
+#[test]
+fn get_slot_without_using() {
+    let mut slab = Slab::<usize, usize>::with_capacity(1);
+    let key = slab.slot().key();
+    assert_eq!(key, slab.slot().key());
+}
+
+#[test]
+#[should_panic]
+fn invalid_get_panics() {
+    let slab = Slab::<usize, usize>::with_capacity(1);
+    slab[0];
+}
+
+#[test]
+#[should_panic]
+fn double_remove_panics() {
+    let mut slab = Slab::<_, usize>::with_capacity(1);
+    let key = slab.store(123);
+    slab.remove(key);
+    slab.remove(key);
+}
+
+#[test]
+#[should_panic]
+fn invalid_remove_panics() {
+    let mut slab = Slab::<usize, usize>::with_capacity(1);
+    slab.remove(0);
+}
+
+#[test]
+fn slab_get_mut() {
+    let mut slab = Slab::<_, usize>::new();
+    let key = slab.store(1);
+
+    slab[key] = 2;
+    assert_eq!(slab[key], 2);
+
+    *slab.get_mut(key).unwrap() = 3;
+    assert_eq!(slab[key], 3);
+}
+
+#[test]
+fn reserve_does_not_allocate_if_available() {
+    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut keys = vec![];
+
+    for i in 0..10 {
+        keys.push(slab.store(i));
+    }
+
+    for key in keys {
+        slab.remove(key);
+    }
+
+    slab.reserve(10);
+    assert_eq!(10, slab.capacity());
+}
+
+#[test]
+fn reserve_exact_does_not_allocate_if_available() {
+    let mut slab = Slab::<_, usize>::with_capacity(10);
+    let mut keys = vec![];
+
+    for i in 0..10 {
+        keys.push(slab.store(i));
+    }
+
+    for key in keys {
+        slab.remove(key);
+    }
+
+    slab.reserve_exact(10);
+    assert_eq!(10, slab.capacity());
+}
+
+#[test]
+fn test_key_trait() {
+    #[derive(Debug, Eq, PartialEq)]
+    pub struct MyKey(usize);
+
+    impl From<usize> for MyKey {
+        fn from(i: usize) -> MyKey { MyKey(i) }
+    }
+
+    impl Into<usize> for MyKey {
+        fn into(self) -> usize { self.0 }
+    }
+
+    let mut slab = Slab::<_, MyKey>::with_capacity(1);
+    let key: MyKey = slab.store(10);
+
+    assert_eq!(key, MyKey(0));
+    assert_eq!(slab[key], 10);
+}
+
+
+#[test]
+fn retain() {
+    let mut slab = Slab::<_, usize>::with_capacity(2);
+
+    let key1 = slab.store(0);
+    let key2 = slab.store(1);
+
+    slab.retain(|x| x % 2 == 0);
+
+    assert_eq!(slab.len(), 1);
+    assert_eq!(slab[key1], 0);
+    assert!(!slab.contains(key2));
+
+    // Ensure consistency is retained
+    let key = slab.store(123);
+    assert_eq!(key, key2);
+
+    assert_eq!(2, slab.len());
+    assert_eq!(2, slab.capacity());
+
+    // Inserting another element grows
+    let key = slab.store(345);
+    assert_eq!(key, 2);
+
+    assert_eq!(4, slab.capacity());
+}
+
+#[test]
+fn iter() {
+    let mut slab = Slab::<_, usize>::new();
+
+    for i in 0..4 {
+        slab.store(i);
+    }
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert_eq!(vals, vec![0, 1, 2, 3]);
+
+    slab.remove(1);
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert_eq!(vals, vec![0, 2, 3]);
+}
+
+#[test]
+fn iter_mut() {
+    let mut slab = Slab::<_, usize>::new();
+
+    for i in 0..4 {
+        slab.store(i);
+    }
+
+    for e in slab.iter_mut() {
+        *e = *e + 1;
+    }
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert_eq!(vals, vec![1, 2, 3, 4]);
+
+    slab.remove(2);
+
+    for e in slab.iter_mut() {
+        *e = *e + 1;
+    }
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert_eq!(vals, vec![2, 3, 5]);
+}
+
+#[test]
+fn clear() {
+    let mut slab = Slab::<_, usize>::new();
+
+    for i in 0..4 {
+        slab.store(i);
+    }
+
+    // clear full
+    slab.clear();
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert!(vals.is_empty());
+
+    assert_eq!(0, slab.len());
+    assert_eq!(4, slab.capacity());
+
+    for i in 0..2 {
+        slab.store(i);
+    }
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert_eq!(vals, vec![0, 1]);
+
+    // clear half-filled
+    slab.clear();
+
+    let vals: Vec<_> = slab.iter().map(|r| *r).collect();
+    assert!(vals.is_empty());
+}

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -157,7 +157,10 @@ fn retain() {
     let key1 = slab.insert(0);
     let key2 = slab.insert(1);
 
-    slab.retain(|x| *x % 2 == 0);
+    slab.retain(|key, x| {
+        assert_eq!(key, *x);
+        *x % 2 == 0
+    });
 
     assert_eq!(slab.len(), 1);
     assert_eq!(slab[key1], 0);

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -61,24 +61,24 @@ fn insert_get_remove_many() {
 }
 
 #[test]
-fn insert_with_slot() {
+fn insert_with_vacant_entry() {
     let mut slab = Slab::with_capacity(1);
     let key;
 
     {
-        let slot = slab.slot();
-        key = slot.key();
-        slot.insert(123);
+        let entry = slab.vacant_entry();
+        key = entry.key();
+        entry.insert(123);
     }
 
     assert_eq!(123, slab[key]);
 }
 
 #[test]
-fn get_slot_without_using() {
+fn get_vacant_entry_without_using() {
     let mut slab = Slab::<usize>::with_capacity(1);
-    let key = slab.slot().key();
-    assert_eq!(key, slab.slot().key());
+    let key = slab.vacant_entry().key();
+    assert_eq!(key, slab.vacant_entry().key());
 }
 
 #[test]


### PR DESCRIPTION
he goal of the rewrite is to make the APIs more idiomatic and more in line with other types in the Rust std. Also, any existing function that wasn't necessary has been removed in favor of a smaller API surface.