### PR TITLE
change functions reserve, reserve_exact

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,13 +264,11 @@ impl<T> Slab<T> {
     /// assert!(slab.capacity() >= 11);
     /// ```
     pub fn reserve(&mut self, additional: usize) {
-        let available = self.entries.len() - self.len;
-
-        if available >= additional {
+        if self.capacity() - self.len >= additional {
             return;
         }
-
-        self.entries.reserve(additional - available);
+        let need_add = self.len + additional - self.entries.len();
+        self.entries.reserve(need_add);
     }
 
     /// Reserves the minimum capacity required to store exactly `additional`
@@ -300,13 +298,11 @@ impl<T> Slab<T> {
     /// assert!(slab.capacity() >= 11);
     /// ```
     pub fn reserve_exact(&mut self, additional: usize) {
-        let available = self.entries.len() - self.len;
-
-        if available >= additional {
+        if self.capacity() - self.len >= additional {
             return;
         }
-
-        self.entries.reserve_exact(additional - available);
+        let need_add = self.len + additional - self.entries.len();
+        self.entries.reserve_exact(need_add);
     }
 
     /// Shrinks the capacity of the slab as much as possible.

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -121,15 +121,17 @@ fn reserve_does_not_allocate_if_available() {
     let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
-    for i in 0..10 {
+    for i in 0..6 {
         keys.push(slab.insert(i));
     }
 
-    for key in keys {
+    for key in 0..4 {
         slab.remove(key);
     }
 
-    slab.reserve(10);
+    assert!(slab.capacity() - slab.len() == 8);
+
+    slab.reserve(8);
     assert_eq!(10, slab.capacity());
 }
 
@@ -138,15 +140,17 @@ fn reserve_exact_does_not_allocate_if_available() {
     let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];
 
-    for i in 0..10 {
+    for i in 0..6 {
         keys.push(slab.insert(i));
     }
 
-    for key in keys {
+    for key in 0..4 {
         slab.remove(key);
     }
 
-    slab.reserve_exact(10);
+    assert!(slab.capacity() - slab.len() == 8);
+
+    slab.reserve(8);
     assert_eq!(10, slab.capacity());
 }
 


### PR DESCRIPTION
If `capacity` subtract `len` is equal or greater than `additional`, it already means that there is no need to allocate extra memory.