### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ documentation = "https://docs.rs/slab"
 homepage = "https://github.com/carllerche/slab"
 repository = "https://github.com/carllerche/slab"
 readme = "README.md"
-keywords = ["slab", "allocator"]
+keywords = ["slab", "allocator", "no_std"]
 categories = ["memory-management", "data-structures"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,15 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/slab/0.4.1")]
 #![crate_name = "slab"]
+#![feature(alloc)]
+#![no_std]
 
-use std::{fmt, mem};
-use std::iter::IntoIterator;
-use std::ops;
+extern crate alloc;
+
+use core::{fmt, mem};
+use core::iter::IntoIterator;
+use core::ops;
+use alloc::prelude::Vec;
 
 /// Pre-allocated storage for a uniform data type
 ///
@@ -160,13 +165,13 @@ pub struct VacantEntry<'a, T: 'a> {
 
 /// An iterator over the values stored in the `Slab`
 pub struct Iter<'a, T: 'a> {
-    entries: std::slice::Iter<'a, Entry<T>>,
+    entries: alloc::slice::Iter<'a, Entry<T>>,
     curr: usize,
 }
 
 /// A mutable iterator over the values stored in the `Slab`
 pub struct IterMut<'a, T: 'a> {
-    entries: std::slice::IterMut<'a, Entry<T>>,
+    entries: alloc::slice::IterMut<'a, Entry<T>>,
     curr: usize,
 }
 


### PR DESCRIPTION
`no_std` is a desired feature in many embedded devices.
This patch makes slab a `no_std` crate. It also works well with `std`.

Signed-off-by: Yu Ding <dingelish@gmail.com>