### PR TITLE
Implement Drain iterator

### DIFF
--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -264,3 +264,38 @@ fn clear() {
     let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert!(vals.is_empty());
 }
+
+#[test]
+fn fully_consumed_drain() {
+    let mut slab = Slab::new();
+
+    for i in 0..3 {
+        slab.insert(i);
+    }
+
+    {
+        let mut drain = slab.drain();
+        assert_eq!(Some(0), drain.next());
+        assert_eq!(Some(1), drain.next());
+        assert_eq!(Some(2), drain.next());
+        assert_eq!(None, drain.next());
+    }
+
+    assert!(slab.is_empty());
+}
+
+#[test]
+fn partially_consumed_drain() {
+    let mut slab = Slab::new();
+
+    for i in 0..3 {
+        slab.insert(i);
+    }
+
+    {
+        let mut drain = slab.drain();
+        assert_eq!(Some(0), drain.next());
+    }
+
+    assert!(slab.is_empty())
+}


### PR DESCRIPTION
This PR adds method `drain` to `Slab` which returns the `Drain` iterator which empties the slab and yields all its elements. Works similarly to `Vec::drain` except it doesn't take range and always removes all elements. Implemented as a wrapper on top of `vec::Drain<Entry<T>>`.

This PR also reformats the code with the latest rustfmt (1.0.0). The reformatting is in a separate commit though.