### PR TITLE
Simplify methods and improve panic message consistency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,13 +697,10 @@ impl<T> Slab<T> {
     /// assert!(!slab.contains(hello));
     /// ```
     pub fn contains(&self, key: usize) -> bool {
-        self.entries
-            .get(key)
-            .map(|e| match *e {
-                Entry::Occupied(_) => true,
-                _ => false,
-            })
-            .unwrap_or(false)
+        match self.entries.get(key) {
+            Some(&Entry::Occupied(_)) => true,
+            _ => false,
+        }
     }
 
     /// Retain only the elements specified by the predicate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ impl<T> Slab<T> {
         if self.capacity() - self.len >= additional {
             return;
         }
-        let need_add = self.len + additional - self.entries.len();
+        let need_add = additional - (self.entries.len() - self.len);
         self.entries.reserve(need_add);
     }
 
@@ -308,7 +308,7 @@ impl<T> Slab<T> {
         if self.capacity() - self.len >= additional {
             return;
         }
-        let need_add = self.len + additional - self.entries.len();
+        let need_add = additional - (self.entries.len() - self.len);
         self.entries.reserve_exact(need_add);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,14 +632,11 @@ impl<T> Slab<T> {
             self.entries.push(Entry::Occupied(val));
             self.next = key + 1;
         } else {
-            let prev = mem::replace(&mut self.entries[key], Entry::Occupied(val));
-
-            match prev {
-                Entry::Vacant(next) => {
-                    self.next = next;
-                }
+            self.next = match self.entries.get(key) {
+                Some(&Entry::Vacant(next)) => next,
                 _ => unreachable!(),
-            }
+            };
+            self.entries[key] = Entry::Occupied(val);
         }
     }
 
@@ -664,21 +661,23 @@ impl<T> Slab<T> {
     /// assert!(!slab.contains(hello));
     /// ```
     pub fn remove(&mut self, key: usize) -> T {
-        // Swap the entry at the provided value
-        let prev = mem::replace(&mut self.entries[key], Entry::Vacant(self.next));
+        if let Some(entry) = self.entries.get_mut(key) {
+            // Swap the entry at the provided value
+            let prev = mem::replace(entry, Entry::Vacant(self.next));
 
-        match prev {
-            Entry::Occupied(val) => {
-                self.len -= 1;
-                self.next = key;
-                val
-            }
-            _ => {
-                // Woops, the entry is actually vacant, restore the state
-                self.entries[key] = prev;
-                panic!("invalid key");
+            match prev {
+                Entry::Occupied(val) => {
+                    self.len -= 1;
+                    self.next = key;
+                    return val;
+                }
+                _ => {
+                    // Woops, the entry is actually vacant, restore the state
+                    *entry = prev;
+                }
             }
         }
+        panic!("invalid key");
     }
 
     /// Return `true` if a value is associated with the given key.
@@ -781,8 +780,8 @@ impl<T> ops::Index<usize> for Slab<T> {
     type Output = T;
 
     fn index(&self, key: usize) -> &T {
-        match self.entries[key] {
-            Entry::Occupied(ref v) => v,
+        match self.entries.get(key) {
+            Some(&Entry::Occupied(ref v)) => v,
             _ => panic!("invalid key"),
         }
     }
@@ -790,8 +789,8 @@ impl<T> ops::Index<usize> for Slab<T> {
 
 impl<T> ops::IndexMut<usize> for Slab<T> {
     fn index_mut(&mut self, key: usize) -> &mut T {
-        match self.entries[key] {
-            Entry::Occupied(ref mut v) => v,
+        match self.entries.get_mut(key) {
+            Some(&mut Entry::Occupied(ref mut v)) => v,
             _ => panic!("invalid key"),
         }
     }
@@ -887,8 +886,8 @@ impl<'a, T> VacantEntry<'a, T> {
     pub fn insert(self, val: T) -> &'a mut T {
         self.slab.insert_at(self.key, val);
 
-        match self.slab.entries[self.key] {
-            Entry::Occupied(ref mut v) => v,
+        match self.slab.entries.get_mut(self.key) {
+            Some(&mut Entry::Occupied(ref mut v)) => v,
             _ => unreachable!(),
         }
     }

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -155,6 +155,22 @@ fn reserve_exact_does_not_allocate_if_available() {
 }
 
 #[test]
+#[should_panic(expected = "capacity overflow")]
+fn reserve_does_panic_with_capacity_overflow() {
+    let mut slab = Slab::with_capacity(10);
+    slab.insert(true);
+    slab.reserve(std::usize::MAX);
+}
+
+#[test]
+#[should_panic(expected = "capacity overflow")]
+fn reserve_exact_does_panic_with_capacity_overflow() {
+    let mut slab = Slab::with_capacity(10);
+    slab.insert(true);
+    slab.reserve_exact(std::usize::MAX);
+}
+
+#[test]
 fn retain() {
     let mut slab = Slab::with_capacity(2);
 

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -82,14 +82,21 @@ fn get_vacant_entry_without_using() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "invalid key")]
 fn invalid_get_panics() {
     let slab = Slab::<usize>::with_capacity(1);
-    slab[0];
+    let _ = &slab[0];
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "invalid key")]
+fn invalid_get_mut_panics() {
+    let mut slab = Slab::<usize>::new();
+    let _ = &mut slab[0];
+}
+
+#[test]
+#[should_panic(expected = "invalid key")]
 fn double_remove_panics() {
     let mut slab = Slab::<usize>::with_capacity(1);
     let key = slab.insert(123);
@@ -98,7 +105,7 @@ fn double_remove_panics() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "invalid key")]
 fn invalid_remove_panics() {
     let mut slab = Slab::<usize>::with_capacity(1);
     slab.remove(0);


### PR DESCRIPTION
* Panic with "invalid key" also when key is out of bounds
* Avoid arithmetic overflows in debug mode to panic with "capacity overflow" instead

This should also reduce code size of the functions.