### PR TITLE
Add key_of() method to calculate the key from a &T

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,9 +572,14 @@ impl<T> Slab<T> {
     /// Get the key for an element in the slab.
     ///
     /// The reference must point to an element owned by the slab.
-    /// Otherwise the returned value is unspecified.
+    /// Otherwise this function will panic.
     /// This is a constant-time operation because the key can be calculated
     /// from the reference with pointer arithmetic.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the reference does not point to an element
+    /// of the slab.
     ///
     /// # Examples
     ///
@@ -588,24 +593,31 @@ impl<T> Slab<T> {
     /// ```
     ///
     /// Values are not compared, so passing a reference to a different locaton
-    /// will not return the key:
+    /// will result in a panic:
     ///
-    /// ```
+    /// ```should_panic
     /// # use slab::*;
     ///
     /// let mut slab = Slab::new();
     /// let key = slab.insert(0);
     /// let bad = &0;
-    /// assert!(slab.key_of(bad) != key);
+    /// slab.key_of(bad); // this will panic
+    /// unreachable!();
     /// ```
     pub fn key_of(&self, present_element: &T) -> usize {
         let element_ptr = present_element as *const T as usize;
         let base_ptr = self.entries.as_ptr() as usize;
-        // use wrapping subtraction in case the reference is bad
+        // Use wrapping subtraction in case the reference is bad
         let byte_offset = element_ptr.wrapping_sub(base_ptr);
-        // the division rounds away any offset of T inside Entry
-        // the size of Entry<T> is never zero even if T is due to Vacant(usize)
-        byte_offset / mem::size_of::<Entry<T>>()
+        // The division rounds away any offset of T inside Entry
+        // The size of Entry<T> is never zero even if T is due to Vacant(usize)
+        let key = byte_offset / mem::size_of::<Entry<T>>();
+        // Prevent returning unspecified (but out of bounds) values
+        if key >= self.entries.len() {
+            panic!("The reference points to a value outside this slab");
+        }
+        // The reference cannot point to a vacant entry, because then it would not be valid
+        key
     }
 
     /// Insert a value in the slab, returning key assigned to the value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,6 +569,45 @@ impl<T> Slab<T> {
         }
     }
 
+    /// Get the key for an element in the slab.
+    ///
+    /// The reference must point to an element owned by the slab.
+    /// Otherwise the returned value is unspecified.
+    /// This is a constant-time operation because the key can be calculated
+    /// from the reference with pointer arithmetic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slab::*;
+    ///
+    /// let mut slab = Slab::new();
+    /// let key = slab.insert(String::from("foo"));
+    /// let value = &slab[key];
+    /// assert_eq!(slab.key_of(value), key);
+    /// ```
+    ///
+    /// Values are not compared, so passing a reference to a different locaton
+    /// will not return the key:
+    ///
+    /// ```
+    /// # use slab::*;
+    ///
+    /// let mut slab = Slab::new();
+    /// let key = slab.insert(0);
+    /// let bad = &0;
+    /// assert!(slab.key_of(bad) != key);
+    /// ```
+    pub fn key_of(&self, present_element: &T) -> usize {
+        let element_ptr = present_element as *const T as usize;
+        let base_ptr = self.entries.as_ptr() as usize;
+        // use wrapping subtraction in case the reference is bad
+        let byte_offset = element_ptr.wrapping_sub(base_ptr);
+        // the division rounds away any offset of T inside Entry
+        // the size of Entry<T> is never zero even if T is due to Vacant(usize)
+        byte_offset / mem::size_of::<Entry<T>>()
+    }
+
     /// Insert a value in the slab, returning key assigned to the value.
     ///
     /// The returned key can later be used to retrieve or remove the value using indexed

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -117,6 +117,34 @@ fn slab_get_mut() {
 }
 
 #[test]
+fn key_of_tagged() {
+    let mut slab = Slab::new();
+    slab.insert(0);
+    assert_eq!(slab.key_of(&slab[0]), 0);
+}
+
+#[test]
+fn key_of_layout_optimizable() {
+    // Entry<&str> doesn't need a discriminant tag because it can use the
+    // nonzero-ness of ptr and store Vacant's next at the same offset as len
+    let mut slab = Slab::new();
+    slab.insert("foo");
+    slab.insert("bar");
+    let third = slab.insert("baz");
+    slab.insert("quux");
+    assert_eq!(slab.key_of(&slab[third]), third);
+}
+
+#[test]
+fn key_of_zst() {
+    let mut slab = Slab::new();
+    slab.insert(());
+    let second = slab.insert(());
+    slab.insert(());
+    assert_eq!(slab.key_of(&slab[second]), second);
+}
+
+#[test]
 fn reserve_does_not_allocate_if_available() {
     let mut slab = Slab::with_capacity(10);
     let mut keys = vec![];


### PR DESCRIPTION
Implements #45 but with a few differences:

* `key_for()` sounds a bit more like it finds the first value that compares equal.
* it is not `unsafe`: It doesn't do anything that requires `unsafe` internally.
* It does not return an `Option`: The option would always have to be unwrapped. If the reference doesn't point to a value owned by the slab, the returned value will be out of bounds, so this shouldn't make bugs silent.
(I've documented this case as unspecified though, to not paint the implementation into a corner.)