### PR TITLE
Implement O(n) FromIterator<(usize, T)> and more iteration features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,6 +1088,19 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<(usize, T)> {
+        while let Some(entry) = self.entries.next_back() {
+            if let Entry::Occupied(v) = entry {
+                let key = self.curr + self.entries.len();
+                return Some((key, v));
+            }
+        }
+
+        None
+    }
+}
+
 // ===== Iter =====
 
 impl<'a, T> Iterator for Iter<'a, T> {
@@ -1108,6 +1121,19 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(self.entries.len()))
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<(usize, &'a T)> {
+        while let Some(entry) = self.entries.next_back() {
+            if let Entry::Occupied(ref v) = *entry {
+                let key = self.curr + self.entries.len();
+                return Some((key, v));
+            }
+        }
+
+        None
     }
 }
 
@@ -1134,6 +1160,19 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
+impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+    fn next_back(&mut self) -> Option<(usize, &'a mut T)> {
+        while let Some(entry) = self.entries.next_back() {
+            if let Entry::Occupied(ref mut v) = *entry {
+                let key = self.curr + self.entries.len();
+                return Some((key, v));
+            }
+        }
+
+        None
+    }
+}
+
 // ===== Drain =====
 
 impl<'a, T> Iterator for Drain<'a, T> {
@@ -1151,5 +1190,17 @@ impl<'a, T> Iterator for Drain<'a, T> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(self.0.len()))
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Drain<'a, T> {
+    fn next_back(&mut self) -> Option<T> {
+        while let Some(entry) = self.0.next_back() {
+            if let Entry::Occupied(v) = entry {
+                return Some(v);
+            }
+        }
+
+        None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1082,6 +1082,10 @@ impl<T> Iterator for IntoIter<T> {
 
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.entries.len()))
+    }
 }
 
 // ===== Iter =====
@@ -1100,6 +1104,10 @@ impl<'a, T> Iterator for Iter<'a, T> {
         }
 
         None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.entries.len()))
     }
 }
 
@@ -1120,6 +1128,10 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.entries.len()))
+    }
 }
 
 // ===== Drain =====
@@ -1135,5 +1147,9 @@ impl<'a, T> Iterator for Drain<'a, T> {
         }
 
         None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.0.len()))
     }
 }

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -185,6 +185,26 @@ fn retain() {
 }
 
 #[test]
+fn into_iter() {
+    let mut slab = Slab::new();
+
+    for i in 0..8 {
+        slab.insert(i);
+    }
+    slab.remove(0);
+    slab.remove(4);
+    slab.remove(5);
+    slab.remove(7);
+
+    let vals: Vec<_> = slab
+        .into_iter()
+        .inspect(|&(key, val)| assert_eq!(key, val))
+        .map(|(_, val)| val)
+        .collect();
+    assert_eq!(vals, vec![1, 2, 3, 6]);
+}
+
+#[test]
 fn iter() {
     let mut slab = Slab::new();
 

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -235,6 +235,46 @@ fn iter_mut() {
 }
 
 #[test]
+fn from_iterator_sorted() {
+    let mut slab = (0..5).map(|i| (i, i)).collect::<Slab<_>>();
+    assert_eq!(slab.len(), 5);
+    assert_eq!(slab[0], 0);
+    assert_eq!(slab[2], 2);
+    assert_eq!(slab[4], 4);
+    assert_eq!(slab.vacant_entry().key(), 5);
+}
+
+#[test]
+fn from_iterator_new_in_order() {
+    // all new keys come in increasing order, but existing keys are overwritten
+    let mut slab = [(0, 'a'), (1, 'a'), (1, 'b'), (0, 'b'), (9, 'a'), (0, 'c')]
+        .iter()
+        .cloned()
+        .collect::<Slab<_>>();
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab[0], 'c');
+    assert_eq!(slab[1], 'b');
+    assert_eq!(slab[9], 'a');
+    assert_eq!(slab.get(5), None);
+    assert_eq!(slab.vacant_entry().key(), 8);
+}
+
+#[test]
+fn from_iterator_unordered() {
+    let mut slab = vec![(1, "one"), (50, "fifty"), (3, "three"), (20, "twenty")]
+        .into_iter()
+        .collect::<Slab<_>>();
+    assert_eq!(slab.len(), 4);
+    assert_eq!(slab.vacant_entry().key(), 0);
+    let mut iter = slab.iter();
+    assert_eq!(iter.next(), Some((1, &"one")));
+    assert_eq!(iter.next(), Some((3, &"three")));
+    assert_eq!(iter.next(), Some((20, &"twenty")));
+    assert_eq!(iter.next(), Some((50, &"fifty")));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
 fn clear() {
     let mut slab = Slab::new();
 

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -205,6 +205,23 @@ fn into_iter() {
 }
 
 #[test]
+fn into_iter_rev() {
+    let mut slab = Slab::new();
+
+    for i in 0..4 {
+        slab.insert(i);
+    }
+
+    let mut iter = slab.into_iter();
+    assert_eq!(iter.next_back(), Some((3, 3)));
+    assert_eq!(iter.next_back(), Some((2, 2)));
+    assert_eq!(iter.next(), Some((0, 0)));
+    assert_eq!(iter.next_back(), Some((1, 1)));
+    assert_eq!(iter.next_back(), None);
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
 fn iter() {
     let mut slab = Slab::new();
 
@@ -226,6 +243,19 @@ fn iter() {
 
     let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![0, 2, 3]);
+}
+
+#[test]
+fn iter_rev() {
+    let mut slab = Slab::new();
+
+    for i in 0..4 {
+        slab.insert(i);
+    }
+    slab.remove(0);
+
+    let vals = slab.iter().rev().collect::<Vec<_>>();
+    assert_eq!(vals, vec![(3, &3), (2, &2), (1, &1)]);
 }
 
 #[test]
@@ -252,6 +282,32 @@ fn iter_mut() {
 
     let vals: Vec<_> = slab.iter().map(|(_, r)| *r).collect();
     assert_eq!(vals, vec![2, 3, 5]);
+}
+
+#[test]
+fn iter_mut_rev() {
+    let mut slab = Slab::new();
+
+    for i in 0..4 {
+        slab.insert(i);
+    }
+    slab.remove(2);
+
+    {
+        let mut iter = slab.iter_mut();
+        assert_eq!(iter.next(), Some((0, &mut 0)));
+        let mut prev_key = !0;
+        for (key, e) in iter.rev() {
+            *e += 10;
+            assert!(prev_key > key);
+            prev_key = key;
+        }
+    }
+
+    assert_eq!(slab[0], 0);
+    assert_eq!(slab[1], 11);
+    assert_eq!(slab[3], 13);
+    assert!(!slab.contains(2));
 }
 
 #[test]
@@ -406,4 +462,16 @@ fn partially_consumed_drain() {
     }
 
     assert!(slab.is_empty())
+}
+
+#[test]
+fn drain_rev() {
+    let mut slab = Slab::new();
+    for i in 0..10 {
+        slab.insert(i);
+    }
+    slab.remove(9);
+
+    let vals: Vec<u64> = slab.drain().rev().collect();
+    assert_eq!(vals, (0..9).rev().collect::<Vec<u64>>());
 }


### PR DESCRIPTION
The `FromIterator` impl uses `recreate_vacant_list()` from #60, so the first commit from there is included here too.
I have not implemented `Extend` because repairing the vacant list if the iterator panics is more trouble than its worth.
cc #42 

Edit:
I collected these commits into one PR because they would not apply independently, but please don't squash them as the commits add different features.
I'll rebase once `recreate_vacant_list()` is on master.