### PR TITLE
`get_unchecked` isn't unchecked

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -686,7 +686,7 @@ impl<T> Slab<T> {
     pub unsafe fn get_unchecked(&self, key: usize) -> &T {
         match *self.entries.get_unchecked(key) {
             Entry::Occupied(ref val) => val,
-            _ => unreachable!(),
+            _ => std::hint::unreachable_unchecked(),
         }
     }
 
@@ -712,7 +712,7 @@ impl<T> Slab<T> {
     pub unsafe fn get_unchecked_mut(&mut self, key: usize) -> &mut T {
         match *self.entries.get_unchecked_mut(key) {
             Entry::Occupied(ref mut val) => val,
-            _ => unreachable!(),
+            _ => std::hint::unreachable_unchecked(),
         }
     }
 


### PR DESCRIPTION
This can be seen in the assembly generated by the `get_unchecked` function. Although there is no bounds checking on the array, it still checks whether the entry is occupied and so there is a branch and panic handling code due to the use of `unreachable!()`. I think that logically, both kinds of checking are the same type of error (you accessed an invalid index), so it makes sense for `get_unchecked` to do no branches at all, only address arithmetic.

The only open question is whether the documentation should be adjusted to use a term other than "bounds checking" here since the set of valid slab indices is not an interval.